### PR TITLE
Fixes equals method not working correctly

### DIFF
--- a/src/StringUtil.php
+++ b/src/StringUtil.php
@@ -154,7 +154,7 @@ class StringUtil
 
     public static function equals($expect, $actual)
     {
-        return $expect === $actual;
+        return self::_value($expect) === self::_value($actual);
     }
 
     public static function trim($str)

--- a/src/StringUtil.php
+++ b/src/StringUtil.php
@@ -154,7 +154,7 @@ class StringUtil
 
     public static function equals($expect, $actual)
     {
-        return false !== strcmp(self::_value($expect), self::_value($actual));
+        return $expect === $actual;
     }
 
     public static function trim($str)

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -99,4 +99,10 @@ class StringTest extends TestCase
             115, 116, 114, 105, 110, 103,
         ], StringUtil::toBytes('string'));
     }
+
+    public function testEquals()
+    {
+        $this->assertTrue(StringUtil::equals('foo', 'foo'));
+        $this->assertFalse(StringUtil::equals('foo', 'bar'));
+    }
 }

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -103,6 +103,7 @@ class StringTest extends TestCase
     public function testEquals()
     {
         $this->assertTrue(StringUtil::equals('foo', 'foo'));
+        $this->assertTrue(StringUtil::equals(null, ''));
         $this->assertFalse(StringUtil::equals('foo', 'bar'));
     }
 }


### PR DESCRIPTION
According to the signature of function [**strcmp**](https://www.php.net/manual/en/function.strcmp.php), the return type would be an integer, checking an integer strictly not equals against with a boolean would always getting a true response.

### Expressions we get all true

- `false !== 1`
- `false !== 0`
- `false !== -1`

It means the method would return `true` whatever values you put into checking with.

This leads to a bug while creating a SLS project from SLS PHP SDK which is depends on the package [alibabacloud-gateway-sls](https://github.com/alibabacloud-sdk-php/alibabacloud-gateway-sls). When it mutates the request under the hood, `Darabonba\GatewaySls\Client::modifyRequest` would not work as expected. In this case, even when the value of the property `$request->reqBodyType` is `json`, using `StringUtil::equals` method for checking with "protobuf" would always return true, causing the API responses error "The body is not valid json string".

https://github.com/alibabacloud-sdk-php/alibabacloud-gateway-sls/blob/b0d3ddb37d278e077601c0a4d5301b274a22256d/src/Client.php#L58